### PR TITLE
Updates readme with github, pantheon and circleci setup steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,6 @@ defaults: &defaults
     - image: quay.io/pantheon-public/build-tools-ci:6.x
   working_directory: ~/example_drops_8_composer
   environment:
-    #=========================================================================
-    # In addition to the environment variables defined in this file, also
-    # add the following variables in the Circle CI UI.
-    #
-    # See: https://circleci.com/docs/2.0/env-vars/
-    #
-    # TERMINUS_SITE:  Name of the Pantheon site to run tests on, e.g. my_site
-    # TERMINUS_TOKEN: The Pantheon machine token
-    # GITHUB_TOKEN:   The GitHub personal access token
-    # GIT_EMAIL:      The email address to use when making commits
-    #
-    # TEST_SITE_NAME: The name of the test site to provide when installing.
-    # ADMIN_PASSWORD: The admin password to use when installing.
-    # ADMIN_EMAIL:    The email address to give the admin when installing.
-    #=========================================================================
     TZ: "/usr/share/zoneinfo/America/Los_Angeles"
 
     # The variables below usually do not need to be modified.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,40 @@ This repo is Pantheon specific at the moment
 * Add Redis to the project
 ![Add redis to the project](https://user-images.githubusercontent.com/1062456/130299370-1e5564db-73dc-4ade-b086-5b7af27d7608.png)
 
+* Go to the Pantheon dashboard for your project.
+
+* Click on the Team tab.
+
+* Click on Add organization
+
+* Search for Kanopi Studios (Important: enter the full term (Kanopi Studios) to find this - if you just enter Kanopi, you will end up with the wrong group and things will not work).
+
+* Select and add Kanopi Studios.
+
+* Also add any Kanopi developers who will be working on the project as team members.
+
+#### Create project's Github repo
+* Go to [https://github.com/kanopi/drupal-starter](https://github.com/kanopi/drupal-starter)
+
+* Click on "Use this template" button.
+
+* Make the owner Kanopi and the repo private, then click "Create repository from template"
+
+* In the new repo, click on Settings and then the Manage Access tab.
+
+* Click on "Invite teams or people" button.
+
+* Search for and add Kanopi Studios and grant them Read access.
+
+* Click on "Add kanopicode to this repository"
+
 #### Update the files to be project specific
+
+* Clone the new repo to your local.
+
+* Create a development branch.
+
+* Make the project specific changes listed below.
 
 * Custom theme
     * Update the name of the theme folder to be project specific. `web/themes/custom/site_theme`
@@ -41,18 +74,56 @@ This repo is Pantheon specific at the moment
         * `.docksal/etc/conf/settings.php` is used for the local settings file for drupal.
         * update `trusted_host_patterns` to match the **repo** name as that is what most likely the virtual host will be. this is so drupal doesn't reject request to the docksal site
     * vhost-overrides.conf
+        * `.docksal/etc/nginx/vhost-overrides.conf`
         * Update the proxy url to use the pantheon machine name for the site you just created.
 * Drupal
-    * Once you have downloaded the DB and are working locally, enabled the redis module.  Then uncomment the redis config in `web/sites/default/settings.php`
+    * Once you have downloaded the DB and are working locally, enable the redis module.
+    * Uncomment the redis config in `web/sites/default/settings.php`
+    * Export config (`fin drush cex`) and commit it to the repo as a new PR.
 * CircleCI
     * `config.yml`
         * Update the `TERMINUS_SITE` variable in line 2 to your Pantheon machine name for the project.
         * Update the `THEME_NAME` variable in line 3 to the folder name for your custom theme.
         * Update `root: ./web/themes/custom/site_theme` to have the proper theme folder name
         * If you would like Slack notifications when builds complete uncomment the slack portion.  You will need to create a new CircleCI slack integration for the channel you want to post updates too and update the webhook URL.
-    * CircleCI project config
-        * Make sure "Only Build PRs" and "Auto Cancel Builds" options are checked. ![Update circleci settings](https://user-images.githubusercontent.com/1062456/130299362-9c04c3e2-e59a-4e73-8dfa-816d8d5316f4.png)
 
+* Run `fin init` to validate your work and local site.
+
+* Commit and push your changes.
+
+* Submit a pull request in github and merge it.
+
+* Circleci won't run this time because we haven't set it up yet. We need to commit the circleci config.yml first so we can setup circleci later.
+
+#### Circleci project setup
+
+* Go to [circleci projects dashboard](https://app.circleci.com/projects/project-dashboard/github/kanopi/)
+
+* Find your new project repo and click the "Set Up Project" button.
+
+* Select the branch name option and select the main branch, and click on the "Lets go" button.
+
+* Click on the gear for the project and click on the Advanced Settings tab.
+
+* Enable "Only build pull request" and "Auto Cancel Builds" options. ![Update circleci settings](https://user-images.githubusercontent.com/1062456/130299362-9c04c3e2-e59a-4e73-8dfa-816d8d5316f4.png)
+
+#### Validation
+
+* Create development branch off of main
+
+* Make a local change (e.g, enable the admin toolbar module and export config)
+
+* Git add, commit and push the change
+
+* Submit a PR in the github repo requesting merge to main branch.
+
+* Validate circleci job and deployment to Pantheon multidev.
+
+* Validate that config change is imported as expected.
+
+* Merge the PR.
+
+* Validate circleci job deployment and Pantheon Dev site.
 
 ## Important links
 
@@ -63,7 +134,6 @@ Please put links to the important places here.  Imagine you know nothing about t
 * Link to CircleCI project page
 * Maybe dev/stage/test environments
 * Links to documentation for any 3rd party services used.
-
 
 ## Setup instructions
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ This repo is Pantheon specific at the moment
 
 * Click on "Add kanopicode to this repository"
 
+* Still in Settings, click on the Branches tab.
+
+* Click on Add Rule.
+
+* Make Branch name pattern match your default branch (e.g., main).
+
+* Select "Require pull request reviews before merging"
+
+* Click Create button
+
 #### Update the files to be project specific
 
 * Clone the new repo to your local.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo is Pantheon specific at the moment
 ![Set the basic details for the site](https://user-images.githubusercontent.com/1062456/130299369-e102b080-f94b-45ce-a706-08392e075c1a.png)
 
 * Add Redis to the project
-![Add redis to the project](https://user-images.githubusercontent.com/1062456/130299370-1e5564db-73dc-4ade-b086-5b7af27d7608.png)
+  ![Add redis to the project](https://user-images.githubusercontent.com/1062456/130299370-1e5564db-73dc-4ade-b086-5b7af27d7608.png)
 
 * Go to the Pantheon dashboard for your project.
 
@@ -65,6 +65,7 @@ This repo is Pantheon specific at the moment
 
 * Custom theme
     * Update the name of the theme folder to be project specific. `web/themes/custom/site_theme`
+
 * Docksal
     * docksal.env
         * Update `hostingsite` to the machine name of the project in Pantheon
@@ -76,10 +77,7 @@ This repo is Pantheon specific at the moment
     * vhost-overrides.conf
         * `.docksal/etc/nginx/vhost-overrides.conf`
         * Update the proxy url to use the pantheon machine name for the site you just created.
-* Drupal
-    * Once you have downloaded the DB and are working locally, enable the redis module.
-    * Uncomment the redis config in `web/sites/default/settings.php`
-    * Export config (`fin drush cex`) and commit it to the repo as a new PR.
+
 * CircleCI
     * `config.yml`
         * Update the `TERMINUS_SITE` variable in line 2 to your Pantheon machine name for the project.
@@ -87,13 +85,17 @@ This repo is Pantheon specific at the moment
         * Update `root: ./web/themes/custom/site_theme` to have the proper theme folder name
         * If you would like Slack notifications when builds complete uncomment the slack portion.  You will need to create a new CircleCI slack integration for the channel you want to post updates too and update the webhook URL.
 
-* Run `fin init` to validate your work and local site.
+* Run `fin init` to validate your local site.
 
-* Commit and push your changes.
+* Run `fin drush cex -y`
 
-* Submit a pull request in github and merge it.
+* On a development branch, git add, commit and push all local changes.
 
-* Circleci won't run this time because we haven't set it up yet. We need to commit the circleci config.yml first so we can setup circleci later.
+* Create a PR in github.
+
+* Circleci won't run this time because we haven't set it up yet. We need to commit the project-specific circleci config.yml first so we can setup circleci later.
+
+* Merge PR (now we have our project-specific circleci config on the main branch so we can reference it from circleci). Circleci job will still not happen.
 
 #### Circleci project setup
 
@@ -107,19 +109,33 @@ This repo is Pantheon specific at the moment
 
 * Enable "Only build pull request" and "Auto Cancel Builds" options. ![Update circleci settings](https://user-images.githubusercontent.com/1062456/130299362-9c04c3e2-e59a-4e73-8dfa-816d8d5316f4.png)
 
-#### Validation
+#### Redis setup
 
-* Create development branch off of main
+* Enable the redis module in your local site.
 
-* Make a local change (e.g, enable the admin toolbar module and export config)
+* Export config.
 
-* Git add, commit and push the change
+* On a development branch, git add, commit and push all local changes.
 
-* Submit a PR in the github repo requesting merge to main branch.
+* Submit a PR on github.
 
-* Validate circleci job and deployment to Pantheon multidev.
+* Validate circleci job and multidev.
 
-* Validate that config change is imported as expected.
+* Merge PR.
+
+* Validate circleci job and Dev site.
+
+* In your local, checkout and pull main branch.
+
+* Creat new development branch.
+
+* Uncomment the redis config in `web/sites/default/settings.php`.
+
+* Git add, commit and push the change.
+
+* Submit a PR in the github repo.
+
+* Validate circleci job and deployment to multidev.
 
 * Merge the PR.
 
@@ -127,12 +143,12 @@ This repo is Pantheon specific at the moment
 
 ## Important links
 
-Please put links to the important places here.  Imagine you know nothing about the project
+Please put links to the important places here.  Imagine you know nothing about the project.
 
 * Hosting platform dashboard for the project.
-* Production URL
-* Link to CircleCI project page
-* Maybe dev/stage/test environments
+* Production URL.
+* Link to CircleCI project page.
+* Maybe dev/stage/test environments.
 * Links to documentation for any 3rd party services used.
 
 ## Setup instructions
@@ -145,14 +161,14 @@ Follow [Docksal install instructions](https://docs.docksal.io/getting-started/se
 
 ### Step #2: Project setup
 
-1. Clone this repo into your Projects directory
+1. Clone this repo into your Projects directory.
 
     ```
     git clone https://github.com/kanopi/drupal-starter.git drupal-starter
     cd drupal-starter
     ```
 
-2. Initialize the site
+2. Initialize the site.
 
     This will initialize local settings and install the site via drush
 
@@ -160,7 +176,7 @@ Follow [Docksal install instructions](https://docs.docksal.io/getting-started/se
     fin init
     ```
 
-3. **On Windows** add `fin hosts add` to your hosts file
+3. **On Windows** add `fin hosts add` to your hosts file.
 
 4. Point your browser to
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repo is Pantheon specific at the moment
 ![Set the basic details for the site](https://user-images.githubusercontent.com/1062456/130299369-e102b080-f94b-45ce-a706-08392e075c1a.png)
 
 * Add Redis to the project
-  ![Add redis to the project](https://user-images.githubusercontent.com/1062456/130299370-1e5564db-73dc-4ade-b086-5b7af27d7608.png)
+![Add redis to the project](https://user-images.githubusercontent.com/1062456/130299370-1e5564db-73dc-4ade-b086-5b7af27d7608.png)
 
 * Go to the Pantheon dashboard for your project.
 


### PR DESCRIPTION
### Teamwork Task
https://kanopi.teamwork.com/#/tasks/26934008

### What we're doing
I have started the [explo repo](https://github.com/kanopi/explo) and [pantheon project](https://dashboard.pantheon.io/sites/5fc62ae6-4b5f-4c46-b994-dd8e5364212f#dev/code) using this starter.

Things seem to be working well (I can't be 100% due to current pantheon issues, but it's looking good so far).

This PR updates the README.md with some additional setup steps. 

It also removes the circleci environmental variable instructions from circleci's config.yml as we no longer need those (thanks for that!).

I'm keeping this in draft until I can fully validate things as I may need to make a few more changes.

### Where we're doing it

### How we'll test it

### Helpful links and documents

