### PR TITLE
fix path to the redis module

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -22,7 +22,7 @@ $settings['config_exclude_modules'] = ['devel', 'twig_xdebug'];
 // Add redis caching
 //if (defined('PANTHEON_ENVIRONMENT')) {
 //  // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
-//  $settings['container_yamls'][] = 'modules/redis/example.services.yml';
+//  $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
 //
 //  //phpredis is built into the Pantheon application container.
 //  $settings['redis.connection']['interface'] = 'PhpRedis';


### PR DESCRIPTION
goes in the contrib folder.   example code from pantheon does not have that