### PR TITLE
fix phpcs report file search param on fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ workflows:
             - ci-tools/post-artifact-to-github:
                 body-prefix: "Click here to view the report:"
                 body-title: phpcs
-                search-for: tmp/phpcs-report.txt
+                search-for: tmp/phpcs.txt
                 when: on_fail
 
       - ci-tools/backstopjs:


### PR DESCRIPTION
The comment on the PR doesn't link to the report properly because it's searching for the wrong thing