### PR TITLE
Update trusted host patterns to any

### DIFF
--- a/.docksal/etc/conf/settings.php
+++ b/.docksal/etc/conf/settings.php
@@ -1,18 +1,22 @@
 <?php
 
-# Docksal DB connection settings.
-$databases['default']['default'] = array (
+/**
+ * @file
+ * Local settings that are copied via fin init.
+ */
+
+// Docksal DB connection settings.
+$databases['default']['default'] = [
   'database' => 'default',
   'username' => 'user',
   'password' => 'user',
   'host' => 'db',
   'driver' => 'mysql',
-);
+];
 
-# Workaround for permission issues with NFS shares in Vagrant.
+// Workaround for permission issues with NFS shares in Vagrant.
 $settings['file_chmod_directory'] = 0777;
 $settings['file_chmod_file'] = 0666;
-
 
 // Local dev caching
 $settings['cache']['bins']['render'] = 'cache.backend.null';
@@ -20,7 +24,5 @@ $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
 $settings['cache']['bins']['page'] = 'cache.backend.null';
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
 
-$settings['trusted_host_patterns'] = array(
-  '^www\.drupal-starter\.docksal',
-  '^drupal-starter\.docksal',
-);
+// Set Trusted Host Patterns to any.
+$settings['trusted_host_patterns'][] = '.*';


### PR DESCRIPTION
Also does some minor PHPCS updates. This file is automatically copied to ./web/sites/default/settings.local.php during the fin init process.

## Description

As a developer, any fork of this should be able to use the trusted host settings.

## Steps to Validate
1. Create new fork
2. Fin init
3. Created site does not fail with the error "The provided host name is not valid for this server."

