### PR TITLE
issue 55 - changes version of kanopi/tour_enhancements to eliminate c…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,6 @@
                     "reference": "1.0"
                 }
             }
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/kanopi/tour_enhancements"
         }
     ],
     "require": {
@@ -64,6 +60,7 @@
         "drupal/seo_starter": "1.x-dev",
         "drupal/simple_sitemap": "^4",
         "drupal/sitemap": "^2.0",
+        "drupal/tour_enhancements": "^1",
         "drupal/tour_ui": "^1.0@beta",
         "drupal/twig_vardumper": "^3.0",
         "drupal/views_bulk_operations": "^4.0",
@@ -73,7 +70,6 @@
         "drush/drush": "^10",
         "joachim-n/composer-manifest": "^1.0",
         "kanopi/launch_checklist": "^1.0",
-        "kanopi/tour_enhancements": "^1.0",
         "oomphinc/composer-installers-extender": "2.0.0",
         "pantheon-systems/drupal-integrations": "^9",
         "pantheon-systems/quicksilver-pushback": "^2",

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "drush/drush": "^10",
         "joachim-n/composer-manifest": "^1.0",
         "kanopi/launch_checklist": "^1.0",
-        "kanopi/tour_enhancements": "^1.1",
+        "kanopi/tour_enhancements": "^1.0",
         "oomphinc/composer-installers-extender": "2.0.0",
         "pantheon-systems/drupal-integrations": "^9",
         "pantheon-systems/quicksilver-pushback": "^2",


### PR DESCRIPTION
### Teamwork Task
https://kanopi.teamwork.com/#/tasks/26985890

### What we're doing
Changing version requirement in composer.json for kanopi/tour_enhancements module in order to eliminate composer install failure.

### Where we're doing it
composer.json

### How we'll test it

1. Pull branch
2. Set terminus site in circle config.yml to a real pantheon site like explo (just so you can execute fin init)
3. Set hostingsite in docksal.env to a real pantheon site like explo (just so you can execute fin init)
4. Run fin init
5. Validate composer install stage completes without fatal errors (note: you will see the failed palantirnet patch I reported in [issue-54](https://github.com/kanopi/drupal-starter/issues/54)

### Helpful links and documents

