### PR TITLE
over-ride minifyhtml configuration locally

### DIFF
--- a/.docksal/etc/conf/settings.php
+++ b/.docksal/etc/conf/settings.php
@@ -26,3 +26,6 @@ $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml'
 
 // Set Trusted Host Patterns to any.
 $settings['trusted_host_patterns'][] = '.*';
+
+$config['minifyhtml.config']['strip_comments'] = FALSE;
+$config['minifyhtml.config']['minify'] = FALSE;


### PR DESCRIPTION
## Description

Since this file becomes /sites/settings.local.php, the added lines will override the minifyhtml config so it can stay enabled and configured.

