### PR TITLE
Set allow_insecure_derivatives to true for webp images 

### DIFF
--- a/.docksal/etc/conf/settings.php
+++ b/.docksal/etc/conf/settings.php
@@ -29,3 +29,6 @@ $settings['trusted_host_patterns'][] = '.*';
 
 $config['minifyhtml.config']['strip_comments'] = FALSE;
 $config['minifyhtml.config']['minify'] = FALSE;
+
+// "Allow Insecure Derivatives" for webp images working locally.
+$config['image.settings']['allow_insecure_derivatives'] = TRUE;


### PR DESCRIPTION
## Description
Webp images don't work when working locally.
Adding settings.local.php `$config['image.settings']['allow_insecure_derivatives'] = TRUE;` to settings fixes this issue.
Related issue https://www.drupal.org/project/imageapi_optimize_webp/issues/3246333

## Steps to Validate
1. Upload an image to a field that is using the webp generated image style.
2. Save
3. The webp should now be displayed on the frontend locally.
