### PR TITLE
Skipping dependabot deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,9 @@ workflows:
           context: kanopi-code
       - deploy_to_pantheon:
           context: kanopi-code
+          filters:
+            branches:
+              ignore: /^dependabot/
           requires:
             - compile-theme
       - ci-tools/lighthouse:


### PR DESCRIPTION
## Description

Skips deploy to pantheon on CI for dependabot branches.

