### PR TITLE
Adds --clone-content flag to build:env:create

### DIFF
--- a/.circleci/scripts/pantheon/dev-multidev
+++ b/.circleci/scripts/pantheon/dev-multidev
@@ -17,7 +17,7 @@ composer run prepare-for-pantheon
 if [[ $CI_BRANCH != "main" ]]
 then
   # Create a new multidev environment (or push to an existing one)
-  terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes
+  terminus -n build:env:create "$TERMINUS_SITE.dev" "$TERMINUS_ENV" --yes --clone-content
 else
   # Push to the dev environment
   terminus -n build:env:push "$TERMINUS_SITE.dev" --yes


### PR DESCRIPTION
## Description
Updates the multidev script to include the --clone-content flag.

Reference: https://github.com/pantheon-systems/terminus-build-tools-plugin#buildenvcreate