### PR TITLE
Add fix to let drupal scaffolding install robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,25 @@ If you want to change the configuration of the Pa11y tests you can edit the [.pa
 Note: This was cribbed from [Phase2](https://github.com/phase2/pa11y-dashboard)
 
 
+### Robots.txt
+#### To append to drupal default scaffolding robots.txt
+- Navigate and open assets/custom-robots.txt
+- Add appended robots.txt to file
+- Run `fin composer install`
+#### To completely overwrite robots.txt
+- Open `composer.json`
+- Change the following:
+  ```
+    "[web-root]/robots.txt": {
+      "append": "assets/custom-robots.txt"
+    },
+  ```
+- To:
+  ```
+  "[web-root]/robots.txt": "assets/custom-robots.txt",
+  ```
+- Run `fin composer.json`
+
 ## Project specific notes
 
 Are there any projects specific quirks or setup that should be noted.

--- a/assets/custom-robots.txt
+++ b/assets/custom-robots.txt
@@ -1,0 +1,3 @@
+#
+# Append to robots.txt
+#

--- a/composer.json
+++ b/composer.json
@@ -157,7 +157,9 @@
             ],
             "file-mapping": {
                 "[web-root]/.htaccess": false,
-                "[web-root]/robots.txt": false,
+                "[web-root]/robots.txt": {
+                    "append": "assets/custom-robots.txt"
+                },
                 "[web-root]/sites/development.services.yml": false
             }
         },


### PR DESCRIPTION
## Description
Composer install was not including the robots.txt file.
This PR will scaffold drupal default robots.txt when running `composer install`.
Included are notes to append or overwrite the robots.txt in the README.md

## Steps to Validate

- In the web directory, there should not be a robots.txt file yet
- Run `fin composer install`
- Check the web directory and verify the robots.txt was created.
- Add some text to assets/custom-robots.txt
- Run `fin composer install` again
- The text added to custom-robots.txt should be appended to web/robots.txt

