### PR TITLE
Added HSTS for Pantheon

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -7,6 +7,7 @@ drush_version: 10
 build_step: false
 search:
   version: 8
+enforce_https: full+subdomains
 protected_web_paths:
   - /private/
   - /sites/default/files/private/


### PR DESCRIPTION
The following will force HTTPS on Pantheon and for HSTS. More information can be found here https://pantheon.io/docs/pantheon-yml#enforce-https--hsts
