### PR TITLE
Skip file permissions hardening on local.

### DIFF
--- a/.docksal/etc/conf/settings.php
+++ b/.docksal/etc/conf/settings.php
@@ -18,6 +18,9 @@ $databases['default']['default'] = [
 $settings['file_chmod_directory'] = 0777;
 $settings['file_chmod_file'] = 0666;
 
+// Skip file system permissions hardening.
+$settings['skip_permissions_hardening'] = TRUE;
+
 // Local dev caching
 $settings['cache']['bins']['render'] = 'cache.backend.null';
 $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';


### PR DESCRIPTION
## Description
On local environments, skipping file permissions hardening prevents the sites/default/ folder from having edit permissions revoked for the docksal user. This especially comes up when upgrading Drupal, when scaffold wants to delete files in sites/default/.