### PR TITLE
issue-129 - removes patch for search_api_autocomplete

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -244,9 +244,6 @@
             },
             "drupal/redirect": {
                 "Setting 'Enforce clean and canonical URLs.' breaks CSS aggregation on multilingual Drupal 10.1.x with browser caching enabled": "https://www.drupal.org/files/issues/2023-07-20/3373123_redirect-7.patch"
-            },
-            "drupal/search_api_autocomplete": {
-                "Undefined constant Drupal\\\\search_api_solr\\\\SolrBackendInterface::SEARCH_API_SOLR_SCHEMA_VERSION": "https://www.drupal.org/files/issues/2023-08-22/3382226-3.patch"
             }
         },
         "merge-plugin": {


### PR DESCRIPTION
## Description
The patch for search_api_autocomplete no longer applies and can be remove. Fix was merged into stable release.

https://www.drupal.org/project/search_api_autocomplete/issues/3382226

## Affected URL
composer install


## Related Tickets

https://github.com/kanopi/drupal-starter/issues/129


