### PR TITLE
issue-131 - changes init user to user 1

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -106,7 +106,7 @@ fi
 echo -e "\n${yellow} ${key} Logging you in. ${key}${NC}"
 echo -e "${NC}This should take ~1 minute and require no input.${NC}"
 echo -e "${green}${divider}${NC}"
-fin drush uli --uid=2
+fin drush uli --uid=1
 
 # Complete
 echo -e "\n${yellow} ${party} Build complete!!! ${reverseparty}${NC}"


### PR DESCRIPTION
## Description
When developer runs fin init, the process fails when it gets to line 109 because it tries to access user 2 which does not exist.

I think the easies fix is to just change it to user 1.

## Affected URL
docksal cli

## Related Tickets

https://github.com/kanopi/drupal-starter/issues/131


## Steps to Validate
Run fin init


