### PR TITLE
Upgrades Drupal Rector for Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,7 @@
     "require-dev": {
         "drupal/core-dev": "^10.1",
         "drupal/upgrade_status": "^4.0",
-        "palantirnet/drupal-rector": "^0.15.1"
+        "palantirnet/drupal-rector": "^0.18"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinder;
-
 use DrupalRector\Set\Drupal10SetList;
 use DrupalRector\Set\Drupal8SetList;
 use DrupalRector\Set\Drupal9SetList;
@@ -16,7 +15,7 @@ return static function(RectorConfig $rectorConfig): void {
   $rectorConfig->sets([
     Drupal8SetList::DRUPAL_8,
     Drupal9SetList::DRUPAL_9,
-    //Drupal10SetList::DRUPAL_10,
+    Drupal10SetList::DRUPAL_10,
   ]);
 
   $parameters = $rectorConfig->parameters();


### PR DESCRIPTION
## Description
> As a developer, I need to keep Rector updated to track Drupal 11 deprecations.