### PR TITLE
issue 138 - fixes blackfire error

### DIFF
--- a/.docksal/commands/init-site
+++ b/.docksal/commands/init-site
@@ -96,6 +96,7 @@ ensure_utils () {
 mkdir -p ~/tmp
 chmod 755 ~/tmp
 sudo localedef -i en_US -f UTF-8 en_US.UTF-8
+sudo rm /etc/apt/sources.list.d/blackfire.list || true
 
 # Project initialization steps
 init_code


### PR DESCRIPTION
## Description
[Issue 138](https://github.com/kanopi/drupal-starter/issues/138)

> As a developer, I need to prevent blackfire errors when running fin init.

## Steps to Validate
1. Pull this branch
2. Run fin init
3. Validate no errors

## Affected URL
[Slack thread](https://kanopi.slack.com/archives/C04CRR2UA/p1702335730704959)


