### PR TITLE
Replaces Drush Launcher. Tells Docksal where to find Drush.

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -78,6 +78,11 @@ fin addon install mkcert --global
 fin mkcert create
 fin project restart
 
+echo -e "\n${yellow} ${lock} Finding Drush. ${lock}${NC}"
+echo -e "${NC}This should take ~1 minute and require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin exec '( [ ! -f /usr/local/bin/drush ] || false) && sudo ln -sF /var/www/vendor/bin/drush /usr/local/bin/drush'
+
 echo -e "\n${yellow} ${arm} Installing Docksal Pull command. ${arm}${NC}"
 echo -e "${NC}This should take ~1 minute and require no input.${NC}"
 echo -e "${green}${divider}${NC}"


### PR DESCRIPTION
Closes #148 
Fix courtesy of @sean-e-dietrich in Slack.
