### PR TITLE
Use npm ci and not npm install

### DIFF
--- a/.docksal/commands/install-theme-tools
+++ b/.docksal/commands/install-theme-tools
@@ -66,7 +66,7 @@ echo "Theme node version: ${NODE_VERSION}"
 nvm install ${NODE_VERSION}
 nvm alias default ${NODE_VERSION}
 nvm use
-npm install --save patch-package
+npm ci --save patch-package
 
 # Run Storybook Develop.
 echo -e "\n${yellow} ${construction} Running Storybook Develop ${construction}${NC}"


### PR DESCRIPTION
## Description
npm ci performs a clean install of all existing dependencies, whereas npm install attempts to update current dependencies when possible.

