### PR TITLE
Removes composer install, adds fencing for first time run

### DIFF
--- a/.docksal/commands/refresh
+++ b/.docksal/commands/refresh
@@ -11,10 +11,10 @@ set -e
 ENVIRONMENT=${1:-"$hostingenv"}
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
 
-fin composer install
-
-echo "Pulling Database..."
-fin pull db -y --hosting-env=${ENVIRONMENT}
+if ! [ -f ./config/sync/core.extension.yml ]; then
+  echo "Pulling Database...";
+  fin pull db -y --hosting-env=${ENVIRONMENT};
+fi
 
 cd ${DOCROOT_PATH}
 


### PR DESCRIPTION
`fin rebuild` exists that includes `composer install`.  Build needs a refresh command that doesn't have it.

The more important aspect is to gate the db request only if the `config/core.extention.yml` exists.