### PR TITLE
Archbee

### DIFF
--- a/.archbee.yaml
+++ b/.archbee.yaml
@@ -1,0 +1,5 @@
+root: ./docs
+structure:
+  summary: SUMMARY.md
+  assets: ./docs/assets
+publishSpace: true

--- a/.gitattributes
+++ b/.gitattributes
@@ -59,3 +59,8 @@
 *.ttf     -text diff
 *.woff    -text diff
 *.woff2   -text diff
+
+# Uncomment to ignore Archbee configuration files.
+# .archbee.yaml export-ignore
+# docs/SUMMARY.md export-ignore
+

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ project.
 - [Saplings Child](docs/SAPLINGS_THEME.md) - Current theme based on
 ui_suite_bootstrap
 - [Emulsify](docs/EMULSIFY.md) - kanopi/kdcl_basic theme was built from
-Emulsify. Currently not in use.
+Emulsify. Currently not in news starts.
 
 
 ## Docksal Commands

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,19 @@
+# Drupal Starter Documentation
+
+## Table of contents
+
+- [Installation](INSTALLATION.md) - for step by step instructions on
+setting this repository up for the first time.
+- [Developer Setup Instructions](DEVELOP.md) - Developers start here to get
+ setup.
+- [About](ABOUT.md) - for details on how this repository is set up and the
+reasoning behind it.
+- [Testing](TESTING.md) - Details about all the testing available in this
+project.
+
+
+## Theme Commands and Setup
+- [Saplings Child](SAPLINGS_THEME.md) - Current theme based on
+ui_suite_bootstrap
+- [Emulsify](EMULSIFY.md) - kanopi/kdcl_basic theme was built from
+Emulsify. Currently not in new starts.


### PR DESCRIPTION
## Description
Adds configuration and example structure for connecting Archbee to this GitHub repository.

### NOTE: 
Archbee is automatically picking up the files inside of /docs.  Merging this PR in will be the only way to verify if the Table of Contents in the SUMMARY.md works.

### Documentation from Archbee:
https://docs.archbee.com/github

### Inside Archbee: (Behind login)
https://app.archbee.com/docs/DiWWfRiSDhrY9rZUW_u_N/w-ZStre25BTp_6wpIJzdD

### Preview link:
https://app.archbee.com/public/PREVIEW-DiWWfRiSDhrY9rZUW_u_N

Would close #180 

## Deploy Notes
Once this is configured, add documentation to Archbee on how to configure for a new project or internal tool.
