### PR TITLE
Removes drupal-library as it is provided by composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,6 @@
             "drupal/core": "-p2"
         },
         "installer-types": [
-            "drupal-library",
             "npm-asset",
             "bower-asset",
             "quicksilver-script",


### PR DESCRIPTION
See `drupal-library` in:
https://github.com/composer/installers?tab=readme-ov-file#current-supported-package-types

Which means we don't need to include it.