### PR TITLE
Conditional Build Steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,8 +211,13 @@ jobs:
 #          include_job_number_field: false
 #          include_project_field: false
 #          webhook: https://hooks.slack.com/services/T02BTKQ5F/B0225B1RPV1/9999111100000
-      - ci-tools/trigger-pipeline:
-          parameters: '{"run_post_build_tests":true}'
+      - when:
+          condition:
+            not:
+              equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - ci-tools/trigger-pipeline:
+                parameters: '{"run_post_build_tests":true}'
 
 workflows:
 


### PR DESCRIPTION
Added condition to not run post build steps on the main branch.

This will stop the trigger from happening when there are no tests on the main branch.