### PR TITLE
Add test name and pass/fail to Cypress reports

### DIFF
--- a/tests/cypress/reporter-config.json
+++ b/tests/cypress/reporter-config.json
@@ -6,7 +6,7 @@
         "json": false,
         "overwrite": false,
         "reportDir": "cypress/results",
-        "reportFilename": "[status]-[name]-[datetime]",
+        "reportFilename": "[status]--[name]--[datetime]",
         "timestamp": "default"
     },
     "mochaJunitReporterReporterOptions": {

--- a/tests/cypress/reporter-config.json
+++ b/tests/cypress/reporter-config.json
@@ -4,9 +4,10 @@
         "charts": true,
         "html": true,
         "json": false,
+        "overwrite": false,
         "reportDir": "cypress/results",
-        "reportFilename": "[status]-[name]",
-        "overwrite": false
+        "reportFilename": "[status]-[name]-[datetime]",
+        "timestamp": "default"
     },
     "mochaJunitReporterReporterOptions": {
         "mochaFile": "cypress/junit/[hash].xml"

--- a/tests/cypress/reporter-config.json
+++ b/tests/cypress/reporter-config.json
@@ -1,12 +1,13 @@
 {
-  "reporterEnabled": "mochawesome, mocha-junit-reporter, spec, json",
-  "mochawesomeReporterOptions": {
-    "reportDir": "cypress/results",
-    "overwrite": false,
-    "html": true,
-    "json": true
-  },
-  "mochaJunitReporterReporterOptions": {
-    "mochaFile": "cypress/junit/[hash].xml"
-  }
+    "reporterEnabled": "mochawesome, mocha-junit-reporter, spec, json",
+    "mochawesomeReporterOptions": {
+        "html": true,
+        "json": false,
+        "reportDir": "cypress/results",
+        "reportFilename": "[status]-[name]",
+        "overwrite": false
+    },
+    "mochaJunitReporterReporterOptions": {
+        "mochaFile": "cypress/junit/[hash].xml"
+    }
 }

--- a/tests/cypress/reporter-config.json
+++ b/tests/cypress/reporter-config.json
@@ -1,6 +1,7 @@
 {
     "reporterEnabled": "mochawesome, mocha-junit-reporter, spec, json",
     "mochawesomeReporterOptions": {
+        "charts": true,
         "html": true,
         "json": false,
         "reportDir": "cypress/results",


### PR DESCRIPTION
## Description
Sick of having to open every mochareport-001, 002, 003 named files to find the test you want? 

This updates the names of the report to be [pass/fail]--[report_name]--[datetime].html. It also turns off JSON to get rid of some files (I don't think we use the report data as JSON), and adds charts.

## Steps to Validate
1. Update a local with this file change 
2. run `fin cypress run --spec cypress/e2e/system-checks.cy.js`
3. view the report in `cypress/results`
