### PR TITLE
Removes looking for fin. This breaks in the latest release of Docksal

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -32,9 +32,6 @@ key='\xF0\x9F\x94\x91'
 lock='\xF0\x9F\x94\x92'
 arm='\xF0\x9F\x92\xAA'
 
-fin=$(which fin)
-[[ -f ${fin} ]] && source $fin
-
 LEFTHOOK=$(which lefthook || true)
 if [[ "${LEFTHOOK}" == "" ]]; then
   echo -e "\n${yellow} ${construction} Initializing githooks... ${construction}${NC}\n"


### PR DESCRIPTION

This make `fin init` do nothing in the latest release of Docksal.

Thanks to @shirazd for finding it.