### PR TITLE
Disallow tbachert/spi composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,8 @@
             "oomphinc/composer-installers-extender": true,
             "rvtraveller/qs-composer-installer": true,
             "ewcomposer/unpack": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "tbachert/spi": false
         }
     }
 }


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3478895#comment-15816720

> catch at Third and Grove commented 16 October 2024 at 02:39

> It's fine to set it to allowed false because it only runs during tests. Not sure where would be best to document this. I guess a change record would be a start.

> We might want to file an upstream issue asking whether it really needs to be a dependency too though, or at least find the upstream commit where it was added.
