### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,6 +42,9 @@
 *.xml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.yml     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
+# PHPStan's baseline uses tabs instead of spaces.
+core/.phpstan-baseline.php text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tabwidth=2 diff=php linguist-language=php
+
 # Define binary file attributes.
 # - Do not treat them as text.
 # - Include binary diff in patches instead of "binary files differ."
@@ -63,4 +66,3 @@
 # Uncomment to ignore Archbee configuration files.
 # .archbee.yaml export-ignore
 # docs/SUMMARY.md export-ignore
-


### PR DESCRIPTION
https://www.drupal.org/project/drupal/issues/3426548#comment-15485744

alexpott as a volunteer and at Acro Commerce, Thunder commented 12 March 2024 at 10:44

> We need to add to .gitattributes so that git doesn't complain about whitespace errors in the new baseline file. This is because PHPStan's baseline generator uses tabs whereas we tell git that that is a whitespace error for PHP. 