### PR TITLE
Update docksal.env

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -25,7 +25,7 @@ THEMENAME="saplings_child"
 
 # Hosting Variables.
 hostingplatform="pantheon"
-hostingsite="pantheon_project_machine_name"
+hostingsite="pantheon-project-machine-name"
 hostingenv="dev"
 
 # Update with the Pantheon D7 machine name and environment.


### PR DESCRIPTION
When spinning up drupal-starter for testing/development, this change will get rid of this annoying yellow warning.

`WARNING:  The VIRTUAL_HOST has been modified from pantheon_project_machine_name.docksal.site to pantheon-project-machine-name.docksal.site to comply with browser standards.`
