### PR TITLE
Adds a `testenv` command to spin up a testing environment

### DIFF
--- a/.docksal/commands/init
+++ b/.docksal/commands/init
@@ -45,7 +45,6 @@ if [[ "${LEFTHOOK}" == "" ]]; then
 fi
 
 #-------------------------- Execution -------------------------------------
-#-------------------------- Execution -------------------------------------
 # Initializing Githooks
 echo -e "\n${yellow} ${construction} Initializing githooks. ${construction}${NC}"
 echo -e "${NC}This should require no input.${NC}"
@@ -98,14 +97,14 @@ fin init-site
 
 # Here's where you could run the theme build.
 # Commenting it out so build finishes faster.
-# Added a comment so themers can run manually.
 # fin install-theme-tools
 # fin install-critical-tools
+
+# Create Solr container.
 fin solr-create-core
 
-# Database
+# Get the database from the server.
 fin refresh
-
 
 echo -e "\n${yellow} ${key} Logging you in. ${key}${NC}"
 echo -e "${NC}This should take ~1 minute and require no input.${NC}"
@@ -118,5 +117,4 @@ echo -e "Visit ${yellow}http://${VIRTUAL_HOST}${NC} in a web browser.${NC}"
 echo -e "Run ${yellow}${theme_tools_command}${NC} to work on the theme."
 echo -e "Run ${yellow}${critical_tools_command}${NC} to install tools for Critical CSS."
 echo -e "${green}${divider}${NC}"
-
 #-------------------------- END: Execution --------------------------------

--- a/.docksal/commands/testenv
+++ b/.docksal/commands/testenv
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+## Initialize stack and testing environment
+##
+## Usage: fin testenv [environment_name] [optional profile_or recipe]
+
+# Abort if anything fails
+set -e
+
+#-------------------------- Helper functions ------------------------------
+
+green='\033[0;32m'
+yellow='\033[1;33m'
+NC='\033[0m'
+
+divider='===================================================\n'
+check='\xE2\x9C\x85'
+construction='\xF0\x9F\x9A\xA7'
+crossmark='\xE2\x9D\x8C'
+hospital='\xF0\x9F\x8F\xA5'
+party='\xF0\x9F\x8E\x88 \xF0\x9F\x8E\x89 \xF0\x9F\x8E\x8A'
+reverseparty='\xF0\x9F\x8E\x8A \xF0\x9F\x8E\x89 \xF0\x9F\x8E\x88'
+rocket='\xF0\x9F\x9A\x80'
+silhouette='\xF0\x9F\x91\xA4'
+lightning='\xE2\x9A\xA1'
+drop='\xF0\x9F\x92\xA7'
+shark='\xF0\x9F\xA6\x88'
+gear='\xEF\xB8\x8F'
+theme_tools_command='fin install-theme-tools'
+critical_tools_command='fin install-critical-tools'
+key='\xF0\x9F\x94\x91'
+lock='\xF0\x9F\x94\x92'
+arm='\xF0\x9F\x92\xAA'
+
+#-------------------------- Execution -------------------------------------
+
+# Check if at least one argument is provided.
+if [ -z "$1" ]; then
+    echo "Usage: $0 <input1> [input2]"
+    exit 1
+fi
+
+# Set the variables from the inputs.
+# Minimal profile is used is another is not provided.
+ENVNAME=$1
+PROFILERECIPE=${2:-minimal}
+
+sed -i '' "s/^hostingsite=\".*\"/hostingsite=\"$ENVNAME\"/" .docksal/docksal.env
+
+echo -e "\n${yellow} ${construction} Initializing NVM... ${construction}${NC}\n"
+echo -e "${NC}This should require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+NVM_DIR="${HOME}/.nvm"
+if [[ ! -d "$NVM_DIR" ]]; then
+    echo -e "${NC}Installing NVM.${NC}"
+    echo -e "${green}${divider}${NC}"
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+    export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+fi
+echo -e "\n${yellow} ${construction} Initializing Cypress... ${construction}${NC}\n"
+echo -e "${NC}This should require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin install-cypress
+
+echo -e "\n${yellow} ${lock} Installing SSL certificate. ${lock}${NC}"
+echo -e "${NC}This should take ~1 minute and require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin addon install mkcert --global
+fin mkcert create
+fin project restart
+
+echo -e "\n${yellow} ${lock} Finding Drush. ${lock}${NC}"
+echo -e "${NC}This should take ~1 minute and require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin exec '([ -f /usr/local/bin/drush ] || true) && sudo ln -sf /var/www/vendor/bin/drush /usr/local/bin/drush'
+
+# Stack initialization
+echo -e "\n${yellow} ${shark} Building Docksal container. ${shark}${NC}"
+echo -e "${NC}This should take ~3 minutes and require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin reset -f
+echo "Waiting 10s for MySQL to initialize.";
+sleep 10
+
+# Site initialization
+fin init-site
+
+# Here's where you could run the theme build.
+# Commenting it out so build finishes faster.
+# Added a comment so themers can run manually.
+# fin install-theme-tools
+# fin install-critical-tools
+fin solr-create-core
+
+# Database
+fin drush si -y $PROFILERECIPE
+
+echo -e "\n${yellow} ${key} Logging you in. ${key}${NC}"
+echo -e "${NC}This should take ~1 minute and require no input.${NC}"
+echo -e "${green}${divider}${NC}"
+fin drush uli
+
+# Complete
+echo -e "\n${yellow} ${party} Build complete!!! ${reverseparty}${NC}"
+echo -e "Run ${yellow}${theme_tools_command}${NC} to work on the theme."
+echo -e "Run ${yellow}${critical_tools_command}${NC} to install tools for Critical CSS."
+echo -e "${green}${divider}${NC}"
+
+#-------------------------- END: Execution --------------------------------

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Command | Description
 `release` | Creates a new release on GitHub and deploys it to Pantheon test environment.
 `share` | Opens a proxy server to your local computer using ngrok.io.
 `solr-create-core` | Called from `init` to create Solr core.
+`testenv` | Creates a new site similar to `init`, but with a local databse. Helpful for testing acnd contributing.
 `tickle` | Wakes up the remote migration source environment every 5 minutes.
 `uuid-rm` | Helper command for Drupal Recipe builders that removes UUIDs from config files.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Command | Description
 `release` | Creates a new release on GitHub and deploys it to Pantheon test environment.
 `share` | Opens a proxy server to your local computer using ngrok.io.
 `solr-create-core` | Called from `init` to create Solr core.
-`testenv` | Creates a new site similar to `init`, but with a local databse. Helpful for testing acnd contributing.
+`testenv` | Creates a new site similar to `init`, but with a local database. Helpful for testing and contributing.
 `tickle` | Wakes up the remote migration source environment every 5 minutes.
 `uuid-rm` | Helper command for Drupal Recipe builders that removes UUIDs from config files.
 


### PR DESCRIPTION
To spin up an environment with a locally created database, you can use the new `testenv` command.

Run `fin testenv anynameyourwant` and it will create a Drupal site for you at anynameyourwant.docksal.site using the minimal profile.

You can also provide a second argument to specify a different profile or recipe.

Using Standard profile:
`fin testenv mynewsite standard`

Using a recipe.
`fin testenv mynewsite recipes/saplings`

Closes #177 