### PR TITLE
Removes unused script

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -24,9 +24,6 @@ workflows:
         description: Database updates, config import.
         script: private/scripts/drush_config_import/drush_config_import.php
       - type: webphp
-        description: Push changes back to GitHub if needed
-        script: private/scripts/quicksilver/quicksilver-pushback/push-back.php
-      - type: webphp
         description: Log to New Relic
         script: private/scripts/sync_code/new_relic_deploy.php
   # Log to New Relic when deploying to test or live.


### PR DESCRIPTION
Closes #230

Is this needed? If so, we need to add it. If not, we need to remove it from the pantheon.yml
```
  sync_code:
    after:
      - type: webphp
        description: Push changes back to GitHub if needed
        script: private/scripts/quicksilver/quicksilver-pushback/push-back.php
```

@sean-e-dietrich:  I don't think we need it honestly. I thought it was buggy but I also know it hasn't been used all the time.