### PR TITLE
fixes config location on pantheon

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -149,8 +149,10 @@ if ($_ENV['PANTHEON_ENVIRONMENT']) {
   }
 }
 
+if (!$_ENV['PANTHEON_ENVIRONMENT']) {
 // Automatically generated include for settings managed by ddev.
-$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
-if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
-  require $ddev_settings;
+  $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+  if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+    require $ddev_settings;
+  }
 }


### PR DESCRIPTION
## Issue
[Drupal is looking in wrong location for config on Pantheon](https://github.com/kanopi/drupal-starter/issues/238) - Issue #238 

## Description

On the updated starter today, everything was working locally OK with respect to importing and exporting config, but on the Pantheon multidevs, config wasn't getting imported and yet the Admin > Config > Development > Configuration synchronization UI and drush cim command were showing no pending changes.

## Solution

The problem is caused by two things:

1. the settings.ddev.php call in settings.php isn't properly fenced off so executes on pantheon when it should only execute on local
2. the settings.ddev.php (in obgyn and cwi - not in this starter where this file does not exist) includes the $settings['config_sync_directory'] and sets it to sites/default/files/sync (so this is where Drupal was looking on pantheon for config and because it was empty, it was deleting all config on the multidevs.

I'm about to submit a PR that resolves this.

## Steps to Validate

See CWI [PR-6](https://github.com/kanopi/cwi/pull/6)
See OBGYN [PR-4](https://github.com/kanopi/ucsfobgyn/pull/4)