### PR TITLE
issue-257 - adds phpstan-drupal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "drush/drush": "^13",
         "joachim-n/composer-manifest": "^1.0",
         "kanopi/shrubs": "^0.2.5",
+        "mglaman/phpstan-drupal": "^2.0",
         "oomphinc/composer-installers-extender": "^2.0.0",
         "pantheon-systems/drupal-integrations": "^11"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "drush/drush": "^13",
         "joachim-n/composer-manifest": "^1.0",
         "kanopi/shrubs": "^0.2.5",
-        "mglaman/phpstan-drupal": "^2.0",
         "oomphinc/composer-installers-extender": "^2.0.0",
         "pantheon-systems/drupal-integrations": "^11"
     },
@@ -37,6 +36,7 @@
         "drupal/default_content": "^2.0@alpha",
         "drupal/devel": "^5.4",
         "ergebnis/composer-normalize": "^2.45",
+        "mglaman/phpstan-drupal": "^2.0",
         "palantirnet/drupal-rector": "^0.21.0",
         "vincentlanglet/twig-cs-fixer": "^3"
     },


### PR DESCRIPTION
## Description
Teamwork Ticket(s): https://kanopi.teamwork.com/app/tasks/29714324
- [ ] Was AI used in this pull request? Yes

This PR adds [mglaman/phpstan-drupal](https://github.com/mglaman/phpstan-drupal) as requested in [issue-257](https://github.com/kanopi/drupal-starter/issues/257) and resolves some of the phpstan errors reported in [arbor issue-26](https://github.com/kanopi/arbor/issues/26)

## Steps to Validate
1. These changes eliminated the "extends unknown class" [PHPstan errors](https://app.circleci.com/pipelines/github/kanopi/ucsf-deb/12/workflows/2f359fb9-fcc5-4e56-b03b-2a3fd5a84de1/jobs/113) on the ucsf-deb project. [Here](https://app.circleci.com/pipelines/github/kanopi/ucsf-deb/15/workflows/6a3505e4-a0f1-4d91-8cf6-1f1271945de1) is the successful phpstan test after I made these changes.

