### PR TITLE
prevents compile theme and other workflows firing up on dependabot branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,9 @@ workflows:
     jobs:
       - compile-theme:
           context: kanopi-code
+          filters:
+            branches:
+              ignore: /^dependabot\/.*/
       - deploy-to-pantheon:
           context: kanopi-code
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,7 +486,7 @@ workflows:
   #
   # To use setup a new trigger in CircleCI.
   # Set the name of the job to be anything.
-  # The parameter cron_env should be added and 
+  # The parameter cron_env should be added and
   # set to be the name of the env to reference for Pantheon.
   #
   # To manually trigger pipeline set the parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           post-steps:
             - store_test_results:
                 path: phpstan-report.xml
@@ -249,6 +250,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           post-steps:
             - store_test_results:
                 path: phpcs-modules-report.xml
@@ -275,6 +277,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           post-steps:
             - store_test_results:
                 path: rector-modules-report.xml
@@ -296,6 +299,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           post-steps:
             - store_test_results:
                 path: rector-themes-report.xml
@@ -317,6 +321,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           post-steps:
             - store_test_results:
                 path: twig-modules-report.xml


### PR DESCRIPTION
## Description

Dependabot branches are triggering CI jobs unnecessarily. The purpose of this PR is to prevent running theme compilation and static analysis workflows since Multidevs are not spun up for Dependabot branches.

Example: https://app.circleci.com/pipelines/github/kanopi/ucsf-dementia/37

**Changes:**
- `compile-theme` (and by extension `deploy-to-pantheon`, `cypress`, `lighthouse`, `pa11y`, `backstopjs`, `sdtt`) — already skipped via the `requires` chain once `compile-theme` is ignored
- `PHPstan`, `PHPcs`, `Rector - modules`, `Rector - themes`, `Twig lint` — also skipped, since Dependabot never touches custom code, and these jobs would always pass pointlessly